### PR TITLE
Refactor/#41 auth routes

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -97,7 +97,7 @@ UserSchema.statics.findByCredentials = function(email, password) {
     }
 
     return new Promise((resolve, reject) => {
-      bcrypt.compare(password, user.password, (err, res) => {
+      bcrypt.compare(password, user.local.password, (err, res) => {
         res ? resolve(user) : reject('password not matched');
       });
     });
@@ -107,10 +107,10 @@ UserSchema.statics.findByCredentials = function(email, password) {
 UserSchema.pre('save', function(next) {
   const user = this;
 
-  if (user.isModified('password')) {
+  if (user.isModified('local.password')) {
     bcrypt.genSalt(10, (err, salt) => {
-      bcrypt.hash(user.password, salt, (err, hash) => {
-        user.password = hash;
+      bcrypt.hash(user.local.password, salt, (err, hash) => {
+        user.local.password = hash;
         next();
       });
     });

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -27,7 +27,6 @@ router.post('/register', (req, res) => {
   user
     .generateAuthToken()
     .then(token => {
-      console.log('user', user);
       res.header('x-auth', token).send(user);
     })
     .catch(err => {

--- a/routes/auth.js
+++ b/routes/auth.js
@@ -18,15 +18,16 @@ router.post('/login', (req, res) => {
 });
 
 router.post('/register', (req, res) => {
-  const body = _.pick(req.body, ['username', 'email', 'password']);
+  const body = _.pick(req.body, ['username', 'email']);
+  body.local = {
+    password: req.body.password
+  };
   let user = new User(body);
 
   user
-    .save()
-    .then(() => {
-      return user.generateAuthToken();
-    })
+    .generateAuthToken()
     .then(token => {
+      console.log('user', user);
       res.header('x-auth', token).send(user);
     })
     .catch(err => {
@@ -53,17 +54,20 @@ router.get(
   }
 );
 
-router.get('/google',
+router.get(
+  '/google',
   passport.authenticate('google', { scope: ['profile', 'email'] })
 );
 
-router.get('/google/redirect',
+router.get(
+  '/google/redirect',
   passport.authenticate('google', {
     // 👇 uncomment when we have those routes
     // failureRedirect: '/login',
     // successRedirect: '/',
     session: false
-  }), (req, res) => {
+  }),
+  (req, res) => {
     res.send('Logged in with google');
   }
 );

--- a/seed/seed.js
+++ b/seed/seed.js
@@ -16,28 +16,36 @@ const users = [
     _id: ids[0],
     username: 'Jethro',
     email: 'jethro@gmail.com',
-    password: 'password1',
+    local: {
+      password: 'password1'
+    },
     token: jwt.sign({ _id: ids[0] }, process.env.JWT_SECRET)
   },
   {
     _id: ids[1],
     username: 'NariRoh',
     email: 'nariroh@gmail.com',
-    password: 'password2',
+    local: {
+      password: 'password2'
+    },
     token: jwt.sign({ _id: ids[1] }, process.env.JWT_SECRET)
   },
   {
     _id: ids[2],
     username: 'JonMaldia',
     email: 'jonmaldia@gmail.com',
-    password: 'password3',
+    local: {
+      password: 'password3'
+    },
     token: jwt.sign({ _id: ids[2] }, process.env.JWT_SECRET)
   },
   {
     _id: ids[3],
     username: 'Alexever',
     email: 'alexever@gmail.com',
-    password: 'password4',
+    local: {
+      password: 'password4'
+    },
     token: jwt.sign({ _id: ids[3] }, process.env.JWT_SECRET)
   }
 ];

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -18,7 +18,7 @@ describe('/auth', () => {
     it('returns users auth token on successful login', done => {
       request(app)
         .post('/auth/login')
-        .send({ email: user.email, password: user.password })
+        .send({ email: user.email, password: user.local.password })
         .expect(200)
         .expect(res => {
           expect(res.headers['x-auth']).to.equal(user.token);


### PR DESCRIPTION
Refactored `/auth/register` route, and updated `User.findByCredentials` and pre-`save` hook on the `User` schema to reflect latest updates to the schema. Fixed the failing test for the `/auth/register` route.
closes #41 